### PR TITLE
Use button elements as links

### DIFF
--- a/src/ButtonLink.js
+++ b/src/ButtonLink.js
@@ -1,0 +1,9 @@
+import {Link} from './Link';
+
+class ButtonLink extends Link {
+  renderElement(props) {
+    return <button ref="link" {...props}>{props.children}</a>
+  }
+}
+
+export default ButtonLink;

--- a/src/Link.js
+++ b/src/Link.js
@@ -28,7 +28,7 @@ class Link extends Component {
   }
 
   onClick(event){
-    const href = this.refs.link.href
+    const href = this.refs.link.getAttribute("href");
 
     if (this.props.onClick){
       this.props.onClick(event)
@@ -47,9 +47,12 @@ class Link extends Component {
     delete props.externalLink
     props.href = props.href || ''
     props.onClick = this.onClick
-    return <a ref="link" {...props}>{props.children}</a>
+    return renderElement(props);
   }
 
+  renderElement(props) {
+    return <a ref="link" {...props}>{props.children}</a>
+  }
 }
 
 export default Link

--- a/src/Link.js
+++ b/src/Link.js
@@ -27,8 +27,16 @@ class Link extends Component {
     this.onClick = this.onClick.bind(this);
   }
 
+  isAbsoluteURL(url) {
+    return url.startsWith("http://")
+        || url.startsWith("https://");
+  }
+
   onClick(event){
-    const href = this.refs.link.getAttribute("href");
+    let href = this.refs.link.getAttribute("href");
+    if (!this.isAbsoluteURL(href)) {
+      href = location.origin + href;
+    }
 
     if (this.props.onClick){
       this.props.onClick(event)


### PR DESCRIPTION
This is a small change to allow users of the library to use Buttons as simple-react-router links.