### PR TITLE
Make router available to page components

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -48,6 +48,7 @@ export default class SimpleReactRouter extends Component {
     const { Component } = router.location.params
     const props = Object.assign({}, this.props)
     props.location = router.location
+    props.router = router;
     return React.createElement(Component, props)
   }
 }


### PR DESCRIPTION
Hi again.

I recently wanted to be able to trigger a redirect programmatically - as opposed to in response to a user clicking on a link. I couldn't find a way of doing it - is there one?

Failing that, I noticed that the router object has a redirect method on it, so I needed to get a reference to it in my page component.

This is a simple PR that just adds the router to the props passed into the child (page) components.

What do you think?