### PR TITLE
feat: add withRedirectTo hoc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import Router from './Router'
 import Link from './Link'
+import withRedirectTo from './withRedirectTo';
 
 export {
   Router,
-  Link
+  Link,
+  withRedirectTo,
 }
 
 export default Router

--- a/src/withRedirectTo.js
+++ b/src/withRedirectTo.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const withRedirectTo = Component => {
+  const WithRedirectTo = (props, context) => (
+    <Component {...props} redirectTo={context.redirectTo} />
+  );
+
+  WithRedirectTo.contextTypes = { redirectTo: () => null };
+  return WithRedirectTo;
+};
+
+export default withRedirectTo;


### PR DESCRIPTION
Add `withRedirectTo` hoc to simplify navigation from within components. Gets the `redirectTo` method from the component context, and passes it trough as a prop.

See https://codesandbox.io/s/3vn0q6k8w6 for an example.

In short:

```js
// HomeButton.js
import { withRedirectTo } from 'simple-react-router';

const HomeButton = ({ redirectTo }) => (
  <button onClick={() => redirectTo('/home')}>
    Go Home
  </button>
);

export default withRedirectTo(HomeButton);
```

Another usage would be to navigate after submitting a form. For example, navigate to `/` after a user logs in, or navigate to `/thank-you` after making a purchase.

Fixes #10 